### PR TITLE
Stop hardcoding force_download=True when fetching weights from HF

### DIFF
--- a/omnicloudmask/download_models.py
+++ b/omnicloudmask/download_models.py
@@ -37,7 +37,9 @@ def download_file_from_google_drive(file_id: str, destination: Path) -> None:
     gdown.download(url, str(destination), quiet=False)
 
 
-def download_file_from_hugging_face(destination: Path) -> None:
+def download_file_from_hugging_face(
+    destination: Path, force_download: bool = False
+) -> None:
     """
     Downloads a file from Hugging Face and saves it at the given destination using
     hf_hub_download.
@@ -45,14 +47,17 @@ def download_file_from_hugging_face(destination: Path) -> None:
     compatibility with the rest of the codebase.
 
     Args:
-        file_id (str): The ID of the file on Hugging Face.
         destination (Path): The local path where the file should be saved.
+        force_download (bool): If True, forces a fresh download even if the file
+            is already cached. Defaults to False so that the local Hugging Face
+            cache is reused, which makes the call resilient to transient network
+            errors on the HEAD request.
     """
     file_name = destination.stem
     safetensor_path = hf_hub_download(
         repo_id="NickWright/OmniCloudMask",
         filename=f"{file_name}.safetensors",
-        force_download=True,
+        force_download=force_download,
         cache_dir=destination.parent,
         local_dir=destination.parent,
     )
@@ -63,11 +68,13 @@ def download_file_from_hugging_face(destination: Path) -> None:
         torch.save(model_state, destination)
 
 
-def download_file(file_id: str, destination: Path, source: str) -> None:
+def download_file(
+    file_id: str, destination: Path, source: str, force_download: bool = False
+) -> None:
     if source == "google_drive":
         download_file_from_google_drive(file_id, destination)
     elif source == "hugging_face":
-        download_file_from_hugging_face(destination)
+        download_file_from_hugging_face(destination, force_download=force_download)
     else:
         raise ValueError(
             "Invalid source. Supported sources are 'google_drive' and 'hugging_face'."
@@ -137,6 +144,7 @@ def get_models(
                 file_id=str(model_dict["google_drive_id"]),
                 destination=destination,
                 source=source,
+                force_download=force_download,
             )
 
         model_paths.append(


### PR DESCRIPTION
## Summary

- Removes the hardcoded `force_download=True` in `download_file_from_hugging_face`, which was forcing every call to bypass the local Hugging Face cache and issue a fresh HEAD request to the Hub.
- Threads the existing `get_models(force_download=...)` flag down through `download_file` and `download_file_from_hugging_face`, so callers control the behaviour. Default is `False` (matching `huggingface_hub`'s convention).
- Fixes #35.

## Why

With `force_download=True`, any transient HEAD failure (timeout, 5xx, flaky network, proxy/SSL hiccup) raises `ValueError: "Force download failed due to the above error."` from `huggingface_hub` — even when a perfectly valid cached copy exists on disk. This makes the library brittle in CI runners, batch pipelines, and restricted networks.

`get_models` already gates the actual download with `not destination.exists() or force_download or destination.stat().st_size <= 1024 * 1024`, so the public API already decides *whether* a download is needed. The size check (`<= 1 MB`) also already protects against partial downloads, which is the most plausible original motivation for forcing the redownload. Forcing it again inside the HF path defeats that gating.

## Behaviour change

- Default callers (`get_models()` with no args, `predict_from_array(...)`, etc.) now reuse the local HF cache on subsequent runs — fewer network hits, resilient to transient HEAD failures.
- Users who explicitly want the previous behaviour can still pass `get_models(force_download=True)` and it now propagates correctly.
- No change to the Google Drive code path.

## Test plan

- [x] `python -c "import ast; ast.parse(open('omnicloudmask/download_models.py').read())"` — syntax OK.
- [ ] Manual: clean cache → first run downloads weights; second run reuses cache without hitting `huggingface.co`.
- [ ] Manual: with `get_models(force_download=True)`, weights are re-downloaded as before.
- [ ] Simulate flaky network on the second run (e.g. block `huggingface.co`); call should succeed using the cached weights instead of raising `"Force download failed..."`.